### PR TITLE
GC Frames as structs, and new `gc_frame!` macro

### DIFF
--- a/src/conv/from_ocaml.rs
+++ b/src/conv/from_ocaml.rs
@@ -1,22 +1,15 @@
-use mlvalues::{raw_ocaml_to_i64, raw_ocaml_to_string, raw_ocaml_to_vecu8, Intnat, RawOCaml};
+use mlvalues::Intnat;
 use value::OCaml;
 
 /// `FromOCaml` implements conversion from OCaml values into Rust values.
 pub unsafe trait FromOCaml<T> {
     /// Convert from OCaml value
     fn from_ocaml(v: OCaml<T>) -> Self;
-
-    /// Convert from raw OCaml value.
-    unsafe fn from_raw_ocaml(v: RawOCaml) -> Self;
 }
 
 unsafe impl FromOCaml<Intnat> for i64 {
     fn from_ocaml(v: OCaml<Intnat>) -> Self {
-        v.as_int() as i64
-    }
-
-    unsafe fn from_raw_ocaml(v: RawOCaml) -> Self {
-        raw_ocaml_to_i64(v)
+        v.as_int()
     }
 }
 
@@ -27,18 +20,10 @@ unsafe impl FromOCaml<String> for Vec<u8> {
         vec.extend_from_slice(raw_bytes);
         vec
     }
-
-    unsafe fn from_raw_ocaml(v: RawOCaml) -> Self {
-        raw_ocaml_to_vecu8(v)
-    }
 }
 
 unsafe impl FromOCaml<String> for String {
     fn from_ocaml(v: OCaml<String>) -> Self {
         v.as_str().to_owned()
-    }
-
-    unsafe fn from_raw_ocaml(v: RawOCaml) -> Self {
-        raw_ocaml_to_string(v)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod value;
 
 pub use crate::closure::OCamlClosure;
 pub use crate::conv::{FromOCaml, ToOCaml, ToOCamlInteger};
-pub use crate::memory::{with_frame, GCtoken, OCamlRef};
+pub use crate::memory::{GCFrame, GCtoken, OCamlRef};
 pub use crate::mlvalues::{tag, Intnat, RawOCaml};
 pub use crate::runtime::init as init_runtime;
 pub use crate::runtime::shutdown as shutdown_runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ mod value;
 
 pub use crate::closure::OCamlClosure;
 pub use crate::conv::{FromOCaml, ToOCaml, ToOCamlInteger};
-pub use crate::memory::{GCFrame, GCtoken, OCamlRef};
-pub use crate::mlvalues::{tag, Intnat, RawOCaml};
+pub use crate::memory::{GCFrame, GCtoken};
+pub use crate::mlvalues::{Intnat, RawOCaml};
 pub use crate::runtime::init as init_runtime;
 pub use crate::runtime::shutdown as shutdown_runtime;
 pub use crate::value::OCaml;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,13 @@
 #[macro_export]
+macro_rules! gc_frame {
+    ($gc:ident) => {
+        let mut frame: $crate::GCFrame = Default::default();
+        frame.initialize();
+        let mut $gc = &mut frame;
+    };
+}
+
+#[macro_export]
 macro_rules! alloc_ocaml {
     { $(($obj:expr).)?$($fn:ident).+($gc:ident) } => {
         {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,9 +1,11 @@
 #[macro_export]
 macro_rules! gc_frame {
-    ($gc:ident) => {
-        let mut frame: $crate::GCFrame = Default::default();
-        frame.initialize();
-        let mut $gc = &mut frame;
+    ($gc:ident, $body:block) => {
+        {
+            let mut frame: $crate::GCFrame = Default::default();
+            let mut $gc = frame.initialize();
+            $body
+        }
     };
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -113,7 +113,7 @@ impl<'a, T> OCamlRef<'a, T> {
         cell.set(x.into());
         OCamlRef {
             _marker: Default::default(),
-            cell: cell,
+            cell,
         }
     }
 }
@@ -140,7 +140,7 @@ impl<T> GCResult<T> {
     pub fn of(raw: RawOCaml) -> GCResult<T> {
         GCResult {
             _marker: Default::default(),
-            raw: raw,
+            raw,
         }
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -64,9 +64,13 @@ impl<'gc> GCFrame<'gc> {
 impl<'gc> Drop for GCFrame<'gc> {
     fn drop(&mut self) {
         assert!(self.block.nitems == 0);
-        unsafe {
-            assert!(caml_local_roots == &mut self.block);
-            caml_local_roots = self.block.next;
+        // In case this happens whith a GCFrame that was not initialized.
+        // We don't want to mess with caml_local_roots in that case.
+        if !self.block.next.is_null() {
+            unsafe {
+                assert!(caml_local_roots == &mut self.block);
+                caml_local_roots = self.block.next;
+            }
         }
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -59,6 +59,10 @@ impl<'gc> GCFrame<'gc> {
     pub fn keep<T>(&self, value: OCaml<T>) -> OCamlRef<'gc, T> {
         OCamlRef::new(self, value)
     }
+
+    pub fn get<T>(&self, reference: OCamlRef<T>) -> OCaml<'gc, T> {
+        make_ocaml(reference.cell.get())
+    }
 }
 
 impl<'gc> Drop for GCFrame<'gc> {
@@ -111,10 +115,6 @@ impl<'a, T> OCamlRef<'a, T> {
             _marker: Default::default(),
             cell: cell,
         }
-    }
-
-    pub fn get<'gc, 'tmp>(&'a self, _gc: &'tmp GCFrame<'gc>) -> OCaml<'tmp, T> {
-        make_ocaml(self.cell.get())
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -87,7 +87,7 @@ unsafe fn reserve_local_root_cell<'gc>(_gc: &GCFrame<'gc>) -> &'gc Cell<RawOCaml
         block.nitems = pos + 1;
         cell
     } else {
-        panic!("Out of local roots");
+        panic!("Out of local roots. Max is LOCALS_BLOCK_SIZE={}", LOCALS_BLOCK_SIZE);
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -46,13 +46,14 @@ pub struct GCFrame<'gc> {
 }
 
 impl<'gc> GCFrame<'gc> {
-    pub fn initialize(&mut self) {
+    pub fn initialize(&mut self) -> &mut Self {
         self.block.tables[0] = self.locals[0].as_ptr();
         self.block.ntables = 1;
         unsafe {
             self.block.next = caml_local_roots;
             caml_local_roots = &mut self.block;
-        }
+        };
+        self
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -55,6 +55,10 @@ impl<'gc> GCFrame<'gc> {
         };
         self
     }
+
+    pub fn keep<T>(&self, value: OCaml<T>) -> OCamlRef<'gc, T> {
+        OCamlRef::new(self, value)
+    }
 }
 
 impl<'gc> Drop for GCFrame<'gc> {

--- a/src/mlvalues.rs
+++ b/src/mlvalues.rs
@@ -1,5 +1,3 @@
-use crate::value::caml_string_length;
-
 pub mod tag;
 
 pub type UIntnat = usize;
@@ -72,18 +70,6 @@ pub unsafe fn string_val(val: RawOCaml) -> *mut u8 {
 pub unsafe fn raw_ocaml_to_i64(raw: RawOCaml) -> i64 {
     assert!(!is_block(raw));
     (raw >> 1) as i64
-}
-
-pub unsafe fn raw_ocaml_to_vecu8(raw: RawOCaml) -> Vec<u8> {
-    assert!(tag_val(raw) == tag::STRING);
-    let len = caml_string_length(raw);
-    let mut vec: Vec<u8> = Vec::with_capacity(len);
-    vec.extend_from_slice(std::slice::from_raw_parts(raw as *const u8, len));
-    vec
-}
-
-pub unsafe fn raw_ocaml_to_string(raw: RawOCaml) -> String {
-    String::from_utf8_unchecked(raw_ocaml_to_vecu8(raw))
 }
 
 #[inline]

--- a/src/mlvalues/tag.rs
+++ b/src/mlvalues/tag.rs
@@ -1,13 +1,13 @@
 pub type Tag = u8;
 
 pub const NO_SCAN: Tag = 251;
-pub const FORWARD: Tag = 250;
-pub const INFIX: Tag = 249;
-pub const OBJECT: Tag = 248;
+// pub const FORWARD: Tag = 250;
+// pub const INFIX: Tag = 249;
+// pub const OBJECT: Tag = 248;
 pub const CLOSURE: Tag = 247;
-pub const LAZY: Tag = 246;
-pub const ABSTRACT: Tag = 251;
+// pub const LAZY: Tag = 246;
+// pub const ABSTRACT: Tag = 251;
 pub const STRING: Tag = 252;
-pub const DOUBLE: Tag = 253;
-pub const DOUBLE_ARRAY: Tag = 254;
-pub const CUSTOM: Tag = 255;
+// pub const DOUBLE: Tag = 253;
+// pub const DOUBLE_ARRAY: Tag = 254;
+// pub const CUSTOM: Tag = 255;

--- a/src/value.rs
+++ b/src/value.rs
@@ -82,9 +82,8 @@ impl<'a> OCaml<'a, String> {
 }
 
 impl<'a> OCaml<'a, Intnat> {
-    pub fn as_int(self) -> Intnat {
-        assert!(!is_block(self.raw));
-        self.raw >> 1
+    pub fn as_int(self) -> i64 {
+        unsafe { raw_ocaml_to_i64(self.raw) }
     }
 
     pub fn of_int(n: i64) -> Self {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,4 @@
-use crate::memory::{GCFrame, OCamlRef};
+use crate::memory::GCFrame;
 use crate::mlvalues::*;
 use crate::mlvalues::tag;
 use std::marker;
@@ -45,10 +45,6 @@ impl<'a, T> OCaml<'a, T> {
             _marker: Default::default(),
             raw: x,
         }
-    }
-
-    pub fn reference<'g, 'gc>(self, gc: &'g GCFrame<'gc>) -> OCamlRef<'gc, T> {
-        OCamlRef::new(gc, self)
     }
 
     pub unsafe fn field<F>(self, i: UIntnat) -> OCaml<'a, F> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -52,7 +52,7 @@ impl<'a, T> OCaml<'a, T> {
         assert!(i < wosize_val(self.raw));
         OCaml {
             _marker: Default::default(),
-            raw: *(self.raw as *const RawOCaml).offset(i as isize),
+            raw: *(self.raw as *const RawOCaml).add(i),
         }
     }
 

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -1,4 +1,4 @@
-use znfe::{with_frame, alloc_ocaml, FromOCaml, Intnat, OCaml, RawOCaml, ToOCaml, ToOCamlInteger};
+use znfe::{alloc_ocaml, gc_frame, FromOCaml, Intnat, OCaml, RawOCaml, ToOCaml, ToOCamlInteger};
 
 #[no_mangle]
 pub fn rust_twice(num: OCaml<'static, Intnat>) -> RawOCaml {
@@ -15,8 +15,7 @@ pub fn rust_increment_bytes(bytes: OCaml<String>, first_n: OCaml<'static, Intnat
         vec[i] += 1;
     }
 
-    with_frame(|gc| {
-        let output = alloc_ocaml! {vec.to_ocaml(gc)};
-        output.into()
-    })
+    gc_frame!(gc);
+    let output = alloc_ocaml! {vec.to_ocaml(gc)};
+    output.into()
 }

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -15,7 +15,8 @@ pub fn rust_increment_bytes(bytes: OCaml<String>, first_n: OCaml<'static, Intnat
         vec[i] += 1;
     }
 
-    gc_frame!(gc);
-    let output = alloc_ocaml! {vec.to_ocaml(gc)};
-    output.into()
+    gc_frame!(gc, {
+        let output = alloc_ocaml! {vec.to_ocaml(gc)};
+        output.into()
+    })
 }

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -19,7 +19,7 @@ pub fn increment_bytes(bytes: &str, first_n: usize) -> String {
         let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
         let bytes_ref = gc.keep(bytes);
         let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
-        let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
+        let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, gc.get(bytes_ref), first_n)};
         let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
         String::from_ocaml(result)
     })

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -17,7 +17,7 @@ mod ocaml {
 pub fn increment_bytes(bytes: &str, first_n: usize) -> String {
     gc_frame!(gc, {
         let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
-        let bytes_ref = bytes.reference(gc);
+        let bytes_ref = gc.keep(bytes);
         let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
         let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
         let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -1,9 +1,6 @@
 extern crate znfe;
 
-use znfe::{
-    alloc_ocaml, call_ocaml, with_frame, FromOCaml, Intnat, OCaml, ToOCaml,
-    ToOCamlInteger,
-};
+use znfe::{alloc_ocaml, call_ocaml, gc_frame, FromOCaml, Intnat, OCaml, ToOCaml, ToOCamlInteger};
 
 mod ocaml {
     use lazy_static::lazy_static;
@@ -18,27 +15,21 @@ mod ocaml {
 }
 
 pub fn increment_bytes(bytes: &str, first_n: usize) -> String {
-    let res = with_frame(|gc| {
-        let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
-        let bytes_ref = bytes.reference(gc);
-        let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
-        let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
-        let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
-        result.into()
-    });
-
-    unsafe { String::from_raw_ocaml(res) }
+    gc_frame!(gc);
+    let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
+    let bytes_ref = bytes.reference(gc);
+    let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
+    let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
+    let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
+    String::from_ocaml(result)
 }
 
 pub fn twice(num: i64) -> i64 {
-    let res = with_frame(|gc| {
-        let num = num.to_ocaml_fixnum();
-        let result = call_ocaml! {ocaml::TWICE(gc, num)};
-        let result: OCaml<Intnat> = result.expect("Error in 'twice' call result");
-        result.into()
-    });
-
-    unsafe { i64::from_raw_ocaml(res) }
+    gc_frame!(gc);
+    let num = num.to_ocaml_fixnum();
+    let result = call_ocaml! {ocaml::TWICE(gc, num)};
+    let result: OCaml<Intnat> = result.expect("Error in 'twice' call result");
+    i64::from_ocaml(result)
 }
 
 // Tests

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -15,21 +15,23 @@ mod ocaml {
 }
 
 pub fn increment_bytes(bytes: &str, first_n: usize) -> String {
-    gc_frame!(gc);
-    let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
-    let bytes_ref = bytes.reference(gc);
-    let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
-    let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
-    let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
-    String::from_ocaml(result)
+    gc_frame!(gc, {
+        let bytes = alloc_ocaml! {bytes.to_ocaml(gc)};
+        let bytes_ref = bytes.reference(gc);
+        let first_n = alloc_ocaml! {(first_n as i64).to_ocaml(gc)};
+        let result = call_ocaml! {ocaml::INCREMENT_BYTES(gc, bytes_ref.get(gc), first_n)};
+        let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
+        String::from_ocaml(result)
+    })
 }
 
 pub fn twice(num: i64) -> i64 {
-    gc_frame!(gc);
-    let num = num.to_ocaml_fixnum();
-    let result = call_ocaml! {ocaml::TWICE(gc, num)};
-    let result: OCaml<Intnat> = result.expect("Error in 'twice' call result");
-    i64::from_ocaml(result)
+    gc_frame!(gc, {
+        let num = num.to_ocaml_fixnum();
+        let result = call_ocaml! {ocaml::TWICE(gc, num)};
+        let result: OCaml<Intnat> = result.expect("Error in 'twice' call result");
+        i64::from_ocaml(result)
+    })
 }
 
 // Tests


### PR DESCRIPTION
The original `with_frame` function followed the same approach as caml-oxide, but it forces the user to work with raw ocaml values that escape the managed scope and are not checked by Rust's borrow checker.

This new `gc_frame!` macro, alond with GC Frames being represented as a value with a Drop trait implemented for cleanup solves the problem.