### PR TITLE
WIP: Add IntoRust trait (counterpart to FromOCaml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Status: **UNSTABLE**
     + [Rule 3: Liveness and scope of OCaml values](#rule-3-liveness-and-scope-of-ocaml-values)
   * [Converting between OCaml and Rust data](#converting-between-ocaml-and-rust-data)
     + [`FromOCaml` trait](#fromocaml-trait)
+    + [`IntoRust` trait](#intorust-trait)
     + [`ToOCaml` trait](#toocaml-trait)
   * [Calling into OCaml from Rust](#calling-into-ocaml-from-rust)
   * [Calling into Rust from OCaml](#calling-into-rust-from-ocaml)
@@ -127,6 +128,10 @@ error[E0597]: `frame` does not live long enough
 #### `FromOCaml` trait
 
 The `FromOCaml` trait implements conversion from OCaml values into Rust values, using the `from_ocaml` function.
+
+#### `IntoRust` trait
+
+`IntoRust` is the counterpart to `FromOCaml` just like `Into` is to `From`. Using `ocaml_val.into_rust()` instead of `Type::from_ocaml(ocaml_val)` is usually more convenient, specially when more complicated types are involved.
 
 #### `ToOCaml` trait
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -1,5 +1,7 @@
 mod from_ocaml;
 mod to_ocaml;
+mod into_rust;
 
 pub use self::from_ocaml::FromOCaml;
 pub use self::to_ocaml::ToOCaml;
+pub use self::into_rust::IntoRust;

--- a/src/conv/into_rust.rs
+++ b/src/conv/into_rust.rs
@@ -1,0 +1,15 @@
+use OCaml;
+use FromOCaml;
+
+pub trait IntoRust<T>: Sized {
+    fn into_rust(self) -> T;
+}
+
+impl<'a, T, U> IntoRust<U> for OCaml<'a, T>
+where
+    U: FromOCaml<T>,
+{
+    fn into_rust(self) -> U {
+        U::from_ocaml(self)
+    }
+}

--- a/src/conv/into_rust.rs
+++ b/src/conv/into_rust.rs
@@ -1,5 +1,5 @@
-use OCaml;
-use FromOCaml;
+use crate::value::OCaml;
+use crate::conv::FromOCaml;
 
 pub trait IntoRust<T>: Sized {
     fn into_rust(self) -> T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod runtime;
 mod value;
 
 pub use crate::closure::{OCamlFn1, OCamlFn2, OCamlFn3, OCamlFn4, OCamlFn5, OCamlResult};
-pub use crate::conv::{FromOCaml, ToOCaml};
+pub use crate::conv::{FromOCaml, ToOCaml, IntoRust};
 pub use crate::error::{OCamlError, OCamlException};
 pub use crate::memory::OCamlRef;
 pub use crate::mlvalues::{Intnat, OCamlBytes, OCamlInt32, OCamlList, OCamlUnboxedFloat, RawOCaml};

--- a/testing/ocaml-caller/rust/src/lib.rs
+++ b/testing/ocaml-caller/rust/src/lib.rs
@@ -1,14 +1,15 @@
-use znfe::{ocaml_alloc, ocaml_export, FromOCaml, Intnat, OCaml, OCamlBytes, OCamlList, ToOCaml};
+use znfe::{ocaml_alloc, ocaml_export, IntoRust, Intnat, OCaml, OCamlBytes, OCamlList, ToOCaml};
 
 ocaml_export! {
     fn rust_twice(_gc, num: OCaml<Intnat>) -> OCaml<Intnat> {
-        let num = i64::from_ocaml(num);
+        let num: i64 = num.into_rust();
         OCaml::of_int(num * 2)
     }
 
     fn rust_increment_bytes(gc, bytes: OCaml<OCamlBytes>, first_n: OCaml<Intnat>) -> OCaml<OCamlBytes> {
-        let first_n = i64::from_ocaml(first_n) as usize;
-        let mut vec = Vec::from_ocaml(bytes);
+        let first_n: i64 = first_n.into_rust();
+        let first_n = first_n as usize;
+        let mut vec: Vec<u8> = bytes.into_rust();
 
         for i in 0..first_n {
             vec[i] += 1;
@@ -18,7 +19,7 @@ ocaml_export! {
     }
 
     fn rust_increment_ints_list(gc, ints: OCaml<OCamlList<Intnat>>) -> OCaml<OCamlList<Intnat>> {
-        let mut vec = <Vec<i64>>::from_ocaml(ints);
+        let mut vec: Vec<i64> = ints.into_rust();
 
         for i in 0..vec.len() {
             vec[i] += 1;
@@ -28,14 +29,14 @@ ocaml_export! {
     }
 
     fn rust_make_tuple(gc, fst: OCaml<String>, snd: OCaml<Intnat>) -> OCaml<(String, Intnat)> {
-        let fst = String::from_ocaml(fst);
-        let snd = i64::from_ocaml(snd);
+        let fst: String = fst.into_rust();
+        let snd: i64 = snd.into_rust();
         let tuple = (fst, snd);
         ocaml_alloc!(tuple.to_ocaml(gc))
     }
 
     fn rust_make_some(gc, value: OCaml<String>) -> OCaml<Option<String>> {
-        let value = String::from_ocaml(value);
+        let value: String = value.into_rust();
         let some_value = Some(value);
         ocaml_alloc!(some_value.to_ocaml(gc))
     }

--- a/testing/rust-caller/src/lib.rs
+++ b/testing/rust-caller/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate znfe;
 
 use znfe::{
-    ocaml_alloc, ocaml_call, ocaml_frame, FromOCaml, Intnat, OCaml, OCamlBytes, OCamlList, ToOCaml,
+    ocaml_alloc, ocaml_call, ocaml_frame, Intnat, IntoRust, OCaml, OCamlBytes, OCamlList, ToOCaml,
 };
 
 mod ocaml {
@@ -23,7 +23,7 @@ pub fn increment_bytes(bytes: &str, first_n: usize) -> String {
         let first_n = ocaml_alloc!((first_n as i64).to_ocaml(gc));
         let result = ocaml_call!(ocaml::increment_bytes(gc, gc.get(bytes_ref), first_n));
         let result: OCaml<String> = result.expect("Error in 'increment_bytes' call result");
-        String::from_ocaml(result)
+        result.into_rust()
     })
 }
 
@@ -33,7 +33,7 @@ pub fn increment_ints_list(ints: &Vec<i64>) -> Vec<i64> {
         let result = ocaml_call!(ocaml::increment_ints_list(gc, ints));
         let result: OCaml<OCamlList<Intnat>> =
             result.expect("Error in 'increment_ints_list' call result");
-        <Vec<i64>>::from_ocaml(result)
+        result.into_rust()
     })
 }
 
@@ -42,7 +42,7 @@ pub fn twice(num: i64) -> i64 {
         let num = OCaml::of_int(num);
         let result = ocaml_call!(ocaml::twice(gc, num));
         let result: OCaml<Intnat> = result.expect("Error in 'twice' call result");
-        i64::from_ocaml(result)
+        result.into_rust()
     })
 }
 
@@ -52,7 +52,7 @@ pub fn make_tuple(fst: String, snd: i64) -> (String, i64) {
         let str = ocaml_alloc!(fst.to_ocaml(gc));
         let result = ocaml_call!(ocaml::make_tuple(gc, str, num));
         let result: OCaml<(String, Intnat)> = result.expect("Error in 'make_tuple' call result");
-        <(String, i64)>::from_ocaml(result)
+        result.into_rust()
     })
 }
 
@@ -61,7 +61,7 @@ pub fn make_some(value: String) -> Option<String> {
         let str = ocaml_alloc!(value.to_ocaml(gc));
         let result = ocaml_call!(ocaml::make_some(gc, str));
         let result: OCaml<Option<String>> = result.expect("Error in 'make_some' call result");
-        <Option<String>>::from_ocaml(result)
+        result.into_rust()
     })
 }
 


### PR DESCRIPTION
` result.into_rust()` is better than `<Option<String>>::from_ocaml(result)`.